### PR TITLE
fix: update Navbar service label from 'Services.cio' to 'Services.seo'

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -162,7 +162,7 @@ const Navbar = () => {
                 transition: 'all 0.3s ease',
               }}
             >
-              Services.cio
+              Services.seo
             </Typography>
             <Typography
               variant="caption"


### PR DESCRIPTION
This pull request includes a minor text update in the `Navbar` component. The change updates the displayed text from "Services.cio" to "Services.seo" for improved accuracy.

* [`src/components/layout/Navbar.tsx`](diffhunk://#diff-3d2e5241bf2cfaf8ba89a0d1290fd3e96f80a98d17172d58ce91f54c6501c302L165-R165): Updated the text in the `Navbar` component to display "Services.seo" instead of "Services.cio".